### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/sparks-training/32e06d7b-4ab6-472f-9b5f-3ceb7c10c71e/9e4318f1-da24-4dd2-b662-11447fa2e3a7/_apis/work/boardbadge/ae6f22d3-d6cc-406f-88ac-2d0b6a174942)](https://dev.azure.com/sparks-training/32e06d7b-4ab6-472f-9b5f-3ceb7c10c71e/_boards/board/t/9e4318f1-da24-4dd2-b662-11447fa2e3a7/Microsoft.RequirementCategory)
 # Quantum Mechanical Keyboard Firmware
 
 [![Current Version](https://img.shields.io/github/tag/qmk/qmk_firmware.svg)](https://github.com/qmk/qmk_firmware/tags)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/sparks-training/32e06d7b-4ab6-472f-9b5f-3ceb7c10c71e/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.